### PR TITLE
Allow touches outside floating browser overlay

### DIFF
--- a/app/src/main/java/com/example/floatingwebview/FloatingWebViewService.kt
+++ b/app/src/main/java/com/example/floatingwebview/FloatingWebViewService.kt
@@ -178,7 +178,9 @@ class FloatingWebViewService : Service() {
             width,
             height,
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY else WindowManager.LayoutParams.TYPE_PHONE,
-            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED,
+            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+                WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED or
+                WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL,
             PixelFormat.TRANSLUCENT
         ).apply {
             gravity = Gravity.TOP or Gravity.START


### PR DESCRIPTION
Summary
- add FLAG_NOT_TOUCH_MODAL to the floating window so input events can reach apps behind the overlay
- keep existing layout and acceleration flags unchanged to preserve appearance

Testing
- Not run (not requested)